### PR TITLE
Add image capture feature

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -146,6 +146,22 @@ function draw() {
 
 }
 
+// if space is pressed, takes picture
+function keyPressed() {
+  if (keyCode == 32) {
+    redraw();
+    takePicture();
+  }
+}
+
+function takePicture() {
+  // grabs all pixels from canvas
+  var picturePixels = get(0, 0, WIDTH, HEIGHT);
+  var randomID = Math.floor((Math.random() * 1000) + 1);
+  // saves picture and names it with an ID
+  save(picturePixels, 'snapchat_clone_' + randomID + '.png');
+  console.log("Picture taken! You look great!")
+}
 
 //State 1 Classes
 function Rainbow(x, y, w, h) {


### PR DESCRIPTION
* Takes a picture of the canvas when space bar is clicked and saves it
to your desktop with a random ID.
* There is an issue where if you run the app again, pictures were
getting erased so I added a random ID between 1 - 1000 to the file name.
Not sure if this is the best way but it avoids the issue for now.
* Taking a picture is binded to space bar for now but we can work on
attaching it to an element in the future.